### PR TITLE
Updated the name of the error code array in user validator

### DIFF
--- a/src/Console/Stubs/UserValidator.stub
+++ b/src/Console/Stubs/UserValidator.stub
@@ -28,7 +28,7 @@ class UserValidator extends AbstractValidator
      *
      * @var array
      */
-    protected $codes = [
+    protected $errorCodes = [
         'email.unique' => 450
     ];
 }


### PR DESCRIPTION
Variable was named incorrectly causing the exception to ignore the custom codes
